### PR TITLE
Favicon & lists styling (#7)

### DIFF
--- a/components/adminContainer.tsx
+++ b/components/adminContainer.tsx
@@ -4,8 +4,11 @@ import Link from 'next/link';
 import Unauthorized from './unauthorized';
 import SpinnerButton from './spinnerButton';
 import Head from 'next/head';
+import { FaviconUtils } from '../utils/favicon';
 
 export default function AdminPageContainer(props: {
+  publicationName?: string,
+  publicationImageUrl?: string,
   children: React.ReactNode,
 }) {
   const [session, loading] = useSession();
@@ -14,6 +17,10 @@ export default function AdminPageContainer(props: {
       <Head>
         <link rel="preconnect" href="https://fonts.gstatic.com" />
         <link href="https://fonts.googleapis.com/css2?family=Martel:wght@300;400;600;700;800&display=swap" rel="stylesheet" />
+        {
+          props.publicationImageUrl &&
+          FaviconUtils.getFaviconLink(props.publicationImageUrl)
+        }
       </Head>
       <nav className='flex justify-between w-full p-2 items-center border-b-2 border-gray-300 shadow-md'>
         {
@@ -28,7 +35,7 @@ export default function AdminPageContainer(props: {
         {
           session && !loading &&
           <>
-            <ul className='m-0 p-0'>
+            <ul className='m-0 p-0 list-none'>
               <li className='nav-item nav-item-border inline-block mr-2'>
                 <Link href="/dashboard">
                   <a className='btn-nav'>Dashboard</a>
@@ -46,7 +53,7 @@ export default function AdminPageContainer(props: {
               </li>
             </ul>
             <div className='inline-flex'>
-              <ul className='flex flex-wrap text-sm md:text-base'>
+              <ul className='flex flex-wrap text-sm md:text-base list-none'>
                 <li className="relative group rounded-lg">
                   {
                     session.user.image ?
@@ -57,7 +64,7 @@ export default function AdminPageContainer(props: {
                           d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                       </svg>
                   }
-                  <ul className="absolute right-0 top-0 mt-12 p-2 rounded-lg shadow-lg hidden bg-white z-10 group-hover:block">
+                  <ul className="absolute right-0 top-0 mt-12 p-2 rounded-lg shadow-lg hidden bg-white z-10 group-hover:block list-none">
                     <li className='nav-item nav-item-border'>
                       <button className='btn-nav' onClick={signOut as any}>Sign out</button>
                     </li>

--- a/components/container.tsx
+++ b/components/container.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import Head from 'next/head';
+import { FaviconUtils } from '../utils/favicon';
 
 export default function PageContainer(props: {
   publicationName?: string,
+  publicationImageUrl?: string,
   children: React.ReactNode,
 }) {
   return (
@@ -11,6 +13,10 @@ export default function PageContainer(props: {
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, user-scalable=0" />
         <link rel="preconnect" href="https://fonts.gstatic.com" />
         <link href="https://fonts.googleapis.com/css2?family=Martel:wght@300;400;600;700;800&display=swap" rel="stylesheet" />
+        {
+          props.publicationImageUrl &&
+          FaviconUtils.getFaviconLink(props.publicationImageUrl)
+        }
       </Head>
       <main>
         {

--- a/pages/archive.tsx
+++ b/pages/archive.tsx
@@ -9,7 +9,7 @@ export default function Archive(props: any) {
   const posts: Post[] = props.posts || [];
   const publication: Publication | undefined = props.publication;
   return (
-    <Container>
+    <Container publicationName={publication?.name} publicationImageUrl={publication?.imageUrl}>
       <Head>
         <title>Archive</title>
         <meta charSet="UTF-8" />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,7 +21,7 @@ export default function Index(props: {
   const router = useRouter();
   const publication: Publication | undefined = props.publication;
   return (
-    <Container publicationName={publication ? publication.name : ''}>
+    <Container publicationName={publication ? publication.name : ''} publicationImageUrl={publication?.imageUrl}>
       <Head>
         <title>{publication?.name}</title>
         <meta charSet="UTF-8" />

--- a/pages/p/[slug].tsx
+++ b/pages/p/[slug].tsx
@@ -5,10 +5,14 @@ import Head from 'next/head';
 import Container from '../../components/container';
 import moment from 'moment';
 
-export default function PostPage(props: any) {
-  const post: Post | undefined = props.post;
+export default function PostPage(props: {
+  publicationName?: string,
+  publicationImageUrl?: string,
+  post: Post,
+}) {
+  const post = props.post;
   return (
-    <Container publicationName={props.publicationName}>
+    <Container publicationName={props.publicationName} publicationImageUrl={props.publicationImageUrl}>
       <div className='flex flex-col justify-center items-center p-4 w-full'>
         <Head>
           <title>{post?.title}</title>
@@ -91,6 +95,7 @@ export const getStaticProps: GetStaticProps = async (context: any): Promise<any>
     return {
       props: {
         publicationName: publication ? publication.name : '',
+        publicationImageUrl: publication ? publication.imageUrl : '',
         post: JSON.parse(JSON.stringify(post))
       },
       revalidate: 300,

--- a/styles/index.css
+++ b/styles/index.css
@@ -91,9 +91,12 @@ blockquote p {
   display: inline;
 }
 
-ol,
 ul {
-  @apply ml-4;
+  @apply ml-4 list-disc;
+}
+
+ol {
+  @apply ml-4 list-decimal;
 }
 
 th {

--- a/utils/favicon.tsx
+++ b/utils/favicon.tsx
@@ -1,0 +1,21 @@
+export const FaviconUtils = {
+  getFaviconLink: (publicationImageUrl: string): JSX.Element | null => {
+    if (publicationImageUrl.toLowerCase().indexOf('.jpg') > -1) {
+      return <link rel="icon" type='image/jpg' href={publicationImageUrl} />
+    }
+
+    if (publicationImageUrl.toLowerCase().indexOf('.png') > -1) {
+      return <link rel='icon' type='image/png' href={publicationImageUrl} />
+    }
+
+    if (publicationImageUrl.toLowerCase().indexOf('.svg') > -1) {
+      return <link rel="icon" type="image/svg+xml" href={publicationImageUrl} />
+    }
+
+    if (publicationImageUrl.toLowerCase().indexOf('.ico') > -1) {
+      return <link rel='icon' href={publicationImageUrl} />
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
* Save draftjs raw content to db

* New and improved wysiwyg editor

* Changed html on post to article

* Updated dashboard links

* Link component for draftail editor

* Member page with logic to delete and send emails to members

* Route fix

* Refactored member endpoints to include delete and email verification actions

* Added toast messages on members page

* Tile image URL prop on post

* Small styling fix

* Extra publish step (page)

* Renamed component issueCard to postCard

* Add image on post card

* Import members using csv file

* style link in draftjs editor

* Convert html to draftjs content

* Styling fix for lists

* Add favicon on public pages

* Dashboard button styling