### PR TITLE
Sitemap & rss feed and various other improvements (#8)

### DIFF
--- a/migration/1609965014983-PublicationIdOnMemberRemoval.ts
+++ b/migration/1609965014983-PublicationIdOnMemberRemoval.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class PublicationIdOnMemberRemoval1609965014983 implements MigrationInterface {
+    name = 'PublicationIdOnMemberRemoval1609965014983'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "public"."IDX_df5675dc1172ee80f697d7d993"`);
+        await queryRunner.query(`ALTER TABLE "public"."members" DROP COLUMN "publicationId"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "public"."members" ADD "publicationId" uuid NOT NULL`);
+        await queryRunner.query(`CREATE INDEX "IDX_df5675dc1172ee80f697d7d993" ON "public"."members" ("publicationId") `);
+    }
+
+}

--- a/models/member.ts
+++ b/models/member.ts
@@ -24,10 +24,6 @@ export class Member {
   emailVerified: boolean;
 
   @Index()
-  @Column({ type: 'uuid', nullable: false })
-  publicationId: string;
-
-  @Index()
   @Column({ type: 'varchar', nullable: true })
   verificationToken: string | undefined;
 
@@ -37,10 +33,9 @@ export class Member {
   @UpdateDateColumn({ name: 'updated_at', type: 'timestamp with time zone' })
   updatedAt: Date | undefined;
 
-  constructor(email: string, emailVerified: boolean, publicationId: string, verificationToken: string | undefined) {
+  constructor(email: string, emailVerified: boolean, verificationToken: string | undefined) {
     this.email = email;
     this.emailVerified = emailVerified;
-    this.publicationId = publicationId;
     this.verificationToken = verificationToken;
   }
 }

--- a/models/post.ts
+++ b/models/post.ts
@@ -76,7 +76,8 @@ export class Post {
     isPublished: boolean,
     source: 'rss' | 'yappl',
     createdDate: Date | undefined,
-    updatedDate: Date | undefined
+    updatedDate: Date | undefined,
+    publishedAt: Date | undefined
   ) {
     this.title = title;
     this.subtitle = subtitle;
@@ -91,5 +92,6 @@ export class Post {
     this.source = source;
     this.createdAt = createdDate;
     this.updatedAt = updatedDate;
+    this.publishedAt = publishedAt;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -135,9 +135,9 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
       "requires": {
         "@babel/highlight": "^7.10.4"
       }
@@ -573,15 +573,6 @@
         "lodash": "^4.17.19"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.10.4"
-          }
-        },
         "@babel/types": {
           "version": "7.12.12",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
@@ -658,26 +649,27 @@
       "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
     },
     "@next/env": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-10.0.4.tgz",
-      "integrity": "sha512-U+XIL75XM1pCmY4+9kYbst/0IptlfDnkFfKdgADBZulQlfng4RB3zirdzkoBtod0lVcrGgDryzOi1mM23RiiVQ=="
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-10.0.5.tgz",
+      "integrity": "sha512-dw6Q7PALIo7nTFfaB4OnRDte3EikrApGtjX/4cRmYXLh+uudDI50aS39MaGeKKZ2mxPKoNiFcY6Slv1f6KIPOw=="
     },
     "@next/polyfill-module": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-10.0.4.tgz",
-      "integrity": "sha512-i2gLUa3YuZ2eQg+d91n+jS4YbPVKg1v0HHIUeJFJMMtpG/apBkTuTLBQGJXe4nKNf7/41NWLDft4ihC3Zfd+Yw=="
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-10.0.5.tgz",
+      "integrity": "sha512-R6ySTTIl6yqyO3Xft7h+QR9Z4e6epEw+AGO125CrwPmCDQ8ASLGltsHYvSHBP7Eae7xaorkXHW0jeI8NewLpew=="
     },
     "@next/react-dev-overlay": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-10.0.4.tgz",
-      "integrity": "sha512-8pKN0PspEtfVFqeSpNQymfXWyV95OTIT0xP9IqILJX2+52ICdU5D+YNuNIwpc4ZOZ0CssM/uYsz6K1FHbCaU7A==",
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-10.0.5.tgz",
+      "integrity": "sha512-olqIaaRvFezzi02V/AYwvmrGbShUNrJDvyZTGNahxXEkiYsuu67llY5IKFM5Oya93/eRqaCCKMn89vpvYtvDcw==",
       "requires": {
-        "@babel/code-frame": "7.10.4",
-        "ally.js": "1.4.1",
+        "@babel/code-frame": "7.12.11",
         "anser": "1.4.9",
         "chalk": "4.0.0",
         "classnames": "2.2.6",
-        "data-uri-to-buffer": "3.0.0",
+        "css.escape": "1.5.1",
+        "data-uri-to-buffer": "3.0.1",
+        "platform": "1.3.6",
         "shell-quote": "1.7.2",
         "source-map": "0.8.0-beta.0",
         "stacktrace-parser": "0.1.10",
@@ -720,12 +712,9 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "data-uri-to-buffer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.0.tgz",
-          "integrity": "sha512-MJ6mFTZ+nPQO+39ua/ltwNePXrfdF3Ww0wP1Od7EePySXN1cP9XNqRQOG3FxTfipp8jx898LUCgBCEP11Qw/ZQ==",
-          "requires": {
-            "buffer-from": "^1.1.1"
-          }
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+          "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
         },
         "has-flag": {
           "version": "4.0.0",
@@ -759,9 +748,9 @@
       }
     },
     "@next/react-refresh-utils": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-10.0.4.tgz",
-      "integrity": "sha512-kZ/37aSQaR0GCZVqh7WDLkeEZqzjPQoZUDdo6TOWiIEb+089AmfYp8A4/1ra9Fu8T4b4wnB76TRl6tp6DeJLXg=="
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-10.0.5.tgz",
+      "integrity": "sha512-Eo+nvW1ZhdkuxBWSsKHGDLNspUaJJQClld9R+H+EtiIuAQtTa8f2rhcQeyUOtvUNQoPyq7Em2PwUqOQD6LOOMA=="
     },
     "@opentelemetry/api": {
       "version": "0.14.0",
@@ -858,10 +847,9 @@
       }
     },
     "@types/node": {
-      "version": "14.14.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.16.tgz",
-      "integrity": "sha512-naXYePhweTi+BMv11TgioE2/FXU4fSl29HAH1ffxVciNsH3rYXjNP2yM8wqmSm7jS20gM8TIklKiTen+1iVncw==",
-      "dev": true
+      "version": "14.14.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
+      "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A=="
     },
     "@types/prop-types": {
       "version": "15.7.3",
@@ -880,9 +868,9 @@
       }
     },
     "@types/react-draft-wysiwyg": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@types/react-draft-wysiwyg/-/react-draft-wysiwyg-1.13.0.tgz",
-      "integrity": "sha512-n6xZtp9jH5/q93SiP60ixeLilEWsHXNneOZ7BLwo9fiAHJWSnB+ZMauVzj4BJwplk4Z8RkkZuxwXYf7U84qDWg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@types/react-draft-wysiwyg/-/react-draft-wysiwyg-1.13.1.tgz",
+      "integrity": "sha512-y5zGYwBa7iHcuqWwGQEh1+KD6Ppho9YG/1Bs3LmUtSROKYesVCaZ6nWuiKSbTn8ipCkuTiBhjMJulNX5L0klHQ==",
       "dev": true,
       "requires": {
         "@types/draft-js": "*",
@@ -896,6 +884,20 @@
       "dev": true,
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/rss": {
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@types/rss/-/rss-0.0.28.tgz",
+      "integrity": "sha512-Kymd0BI1tBOSwOwCN5Y8dtlJegTIF+izS8tJETiivJ7qAJGHhnuZjiunXWqBkgv6dg0ZZWyf0kEfMgkr4YWJzg==",
+      "dev": true
+    },
+    "@types/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-dqYdvN7Sbw8QT/0Ci5rhjE4/iCMJEM0Y9rHpCu+gGXD9Lwbz28t6HI2yegsB6BoV1sShRMU6lAmAcgRjmFy7LA==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@webassemblyjs/ast": {
@@ -1146,15 +1148,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
-    "ally.js": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/ally.js/-/ally.js-1.4.1.tgz",
-      "integrity": "sha1-n7fmuljvrE7pExyymqnuO1QLzx4=",
-      "requires": {
-        "css.escape": "^1.5.0",
-        "platform": "1.3.3"
-      }
-    },
     "anser": {
       "version": "1.4.9",
       "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.9.tgz",
@@ -1239,6 +1232,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+    },
+    "array-flatten": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
+      "optional": true
     },
     "array-unique": {
       "version": "0.3.2",
@@ -1341,14 +1340,14 @@
       "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg=="
     },
     "autoprefixer": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.1.0.tgz",
-      "integrity": "sha512-0/lBNwN+ZUnb5su18NZo5MBIjDaq6boQKZcxwy86Gip/CmXA2zZqUoFQLCNAGI5P25ZWSP2RWdhDJ8osfKEjoQ==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.1.tgz",
+      "integrity": "sha512-dwP0UjyYvROUvtU+boBx8ff5pPWami1NGTrJs9YUsS/oZVbRAcdNHOOuXSA1fc46tgKqe072cVaKD69rvCc3QQ==",
       "requires": {
-        "browserslist": "^4.15.0",
-        "caniuse-lite": "^1.0.30001165",
+        "browserslist": "^4.16.1",
+        "caniuse-lite": "^1.0.30001173",
         "colorette": "^1.2.1",
-        "fraction.js": "^4.0.12",
+        "fraction.js": "^4.0.13",
         "normalize-range": "^0.1.2",
         "postcss-value-parser": "^4.1.0"
       }
@@ -1605,15 +1604,15 @@
       }
     },
     "browserslist": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
-      "integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.1.tgz",
+      "integrity": "sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==",
       "requires": {
-        "caniuse-lite": "^1.0.30001165",
+        "caniuse-lite": "^1.0.30001173",
         "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.621",
+        "electron-to-chromium": "^1.3.634",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.67"
+        "node-releases": "^1.1.69"
       }
     },
     "buffer": {
@@ -1712,9 +1711,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001171",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001171.tgz",
-      "integrity": "sha512-5Alrh8TTYPG9IH4UkRqEBZoEToWRLvPbSQokvzSz0lii8/FOWKG4keO1HoYfPWs8IF/NH/dyNPg1cmJGvV3Zlg=="
+      "version": "1.0.30001173",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001173.tgz",
+      "integrity": "sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -2742,9 +2741,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.633",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.633.tgz",
-      "integrity": "sha512-bsVCsONiVX1abkWdH7KtpuDAhsQ3N3bjPYhROSAXE78roJKet0Y5wznA14JE9pzbwSZmSMAW6KiKYf1RvbTJkA=="
+      "version": "1.3.634",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.634.tgz",
+      "integrity": "sha512-QPrWNYeE/A0xRvl/QP3E0nkaEvYUvH3gM04ZWYtIa6QlSpEetRlRI1xvQ7hiMIySHHEV+mwDSX8Kj4YZY6ZQAw=="
     },
     "elliptic": {
       "version": "6.5.3",
@@ -4450,16 +4449,16 @@
       }
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.45.0"
       }
     },
     "mimic-response": {
@@ -4635,9 +4634,9 @@
       }
     },
     "needle": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
-      "integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.6.0.tgz",
+      "integrity": "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==",
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -4655,17 +4654,17 @@
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
     },
     "next": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-10.0.4.tgz",
-      "integrity": "sha512-WXEYr1FuR2cLuWGN8peYGM6ykmbtwaHvrI6RqR2qrTXUNsW+KU5pzIMK5WPcpqP+xOuMhlykOCJvwJH8qU9FZQ==",
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-10.0.5.tgz",
+      "integrity": "sha512-yr7ap2TLugf0aMHz+3JoKFP9CCkFE+k6jCfdUymORhptjLYZbD3YGlTcUC1CRl+b5Phlbl7m/WUIPde0VcguiA==",
       "requires": {
         "@ampproject/toolbox-optimizer": "2.7.1-alpha.0",
         "@babel/runtime": "7.12.5",
         "@hapi/accept": "5.0.1",
-        "@next/env": "10.0.4",
-        "@next/polyfill-module": "10.0.4",
-        "@next/react-dev-overlay": "10.0.4",
-        "@next/react-refresh-utils": "10.0.4",
+        "@next/env": "10.0.5",
+        "@next/polyfill-module": "10.0.5",
+        "@next/react-dev-overlay": "10.0.5",
+        "@next/react-refresh-utils": "10.0.5",
         "@opentelemetry/api": "0.14.0",
         "ast-types": "0.13.2",
         "babel-plugin-transform-define": "2.0.0",
@@ -4697,7 +4696,7 @@
         "resolve-url-loader": "3.1.2",
         "sass-loader": "10.0.5",
         "schema-utils": "2.7.1",
-        "sharp": "0.26.2",
+        "sharp": "0.26.3",
         "stream-browserify": "3.0.0",
         "style-loader": "1.2.1",
         "styled-jsx": "3.3.2",
@@ -4894,9 +4893,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.67",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-      "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
+      "version": "1.1.69",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.69.tgz",
+      "integrity": "sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA=="
     },
     "nodemailer": {
       "version": "6.4.17",
@@ -5359,9 +5358,9 @@
       }
     },
     "platform": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.3.tgz",
-      "integrity": "sha1-ZGx3ARiZhwtqCQPnXpl+jlHadGE="
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "pnp-webpack-plugin": {
       "version": "1.6.4",
@@ -5377,9 +5376,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.1.tgz",
-      "integrity": "sha512-RhsqOOAQzTgh1UB/IZdca7F9WDb7SUCR2Vnv1x7DbvuuggQIpoDwjK+q0rzoPffhYvWNKX5JSwS4so4K3UC6vA==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.3.tgz",
+      "integrity": "sha512-tdmNCCmxJEsLZNj810qlj8QbvnUNKFL9A5doV+uHrGGK/YNKWEslrytnHDWr9M/GgGjfUFwXCRbxd/b6IoRBXQ==",
       "requires": {
         "colorette": "^1.2.1",
         "nanoid": "^3.1.20",
@@ -6406,9 +6405,9 @@
       }
     },
     "preact": {
-      "version": "10.5.7",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.7.tgz",
-      "integrity": "sha512-4oEpz75t/0UNcwmcsjk+BIcDdk68oao+7kxcpc1hQPNs2Oo3ZL9xFz8UBf350mxk/VEdD41L5b4l2dE3Ug3RYg=="
+      "version": "10.5.9",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.9.tgz",
+      "integrity": "sha512-X4m+4VMVINl/JFQKALOCwa3p8vhMAhBvle0hJ/W44w/WWfNb2TA7RNicDV3K2dNVs57f61GviEnVLiwN+fxiIg=="
     },
     "preact-render-to-string": {
       "version": "5.1.12",
@@ -6419,9 +6418,9 @@
       }
     },
     "prebuild-install": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
-      "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.0.tgz",
+      "integrity": "sha512-h2ZJ1PXHKWZpp1caLw0oX9sagVpL2YTk+ZwInQbQ3QqNd4J03O6MpFNmMTJlkfgPENWqe5kP0WjQLqz5OjLfsw==",
       "optional": true,
       "requires": {
         "detect-libc": "^1.0.3",
@@ -6984,6 +6983,30 @@
         "inherits": "^2.0.1"
       }
     },
+    "rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=",
+      "requires": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.25.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+          "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I="
+        },
+        "mime-types": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+          "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
+          "requires": {
+            "mime-db": "~1.25.0"
+          }
+        }
+      }
+    },
     "run-queue": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -7138,19 +7161,20 @@
       }
     },
     "sharp": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.26.2.tgz",
-      "integrity": "sha512-bGBPCxRAvdK9bX5HokqEYma4j/Q5+w8Nrmb2/sfgQCLEUx/HblcpmOfp59obL3+knIKnOhyKmDb4tEOhvFlp6Q==",
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.26.3.tgz",
+      "integrity": "sha512-NdEJ9S6AMr8Px0zgtFo1TJjMK/ROMU92MkDtYn2BBrDjIx3YfH9TUyGdzPC+I/L619GeYQc690Vbaxc5FPCCWg==",
       "optional": true,
       "requires": {
-        "color": "^3.1.2",
+        "array-flatten": "^3.0.0",
+        "color": "^3.1.3",
         "detect-libc": "^1.0.3",
         "node-addon-api": "^3.0.2",
         "npmlog": "^4.1.2",
-        "prebuild-install": "^5.3.5",
+        "prebuild-install": "^6.0.0",
         "semver": "^7.3.2",
         "simple-get": "^4.0.0",
-        "tar-fs": "^2.1.0",
+        "tar-fs": "^2.1.1",
         "tunnel-agent": "^0.6.0"
       },
       "dependencies": {
@@ -7230,6 +7254,24 @@
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "sitemap": {
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-6.3.5.tgz",
+      "integrity": "sha512-uLz8c5nI31bd4/+nccVWhJx18JxLF+1bAKhhxMv0IYKClSK8wWtANKsl9FOluqmz37ObeBLGVVgNOpg3r+yz/g==",
+      "requires": {
+        "@types/node": "^14.14.14",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "arg": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.0.tgz",
+          "integrity": "sha512-4P8Zm2H+BRS+c/xX1LrHw0qKpEhdlZjLCgWy+d78T9vqa2Z2SiD2wMrYuWIAFy5IZUD7nnNXroRttz+0RzlrzQ=="
+        }
       }
     },
     "smart-buffer": {
@@ -8036,9 +8078,9 @@
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw=="
     },
     "tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "tsscmp": {
       "version": "1.0.6",
@@ -8770,6 +8812,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
     },
     "xml2js": {
       "version": "0.4.23",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "react-modal": "^3.12.1",
     "react-toastify": "^6.2.0",
     "reflect-metadata": "^0.1.13",
+    "rss": "^1.2.2",
+    "sitemap": "^6.3.5",
     "typeorm": "^0.2.29"
   },
   "devDependencies": {
@@ -49,6 +51,7 @@
     "@types/react": "^16.9.50",
     "@types/react-draft-wysiwyg": "^1.13.0",
     "@types/react-modal": "^3.10.6",
+    "@types/rss": "0.0.28",
     "postcss-flexbugs-fixes": "4.2.1",
     "postcss-preset-env": "^6.7.0",
     "tailwindcss": "^2.0.1",

--- a/pages/api/member/[action]/index.ts
+++ b/pages/api/member/[action]/index.ts
@@ -31,7 +31,7 @@ export default async function GenericMemberHandler(req: NextApiRequest, res: Nex
           const existingMember = await memberRepository.findOne({ email: body.email });
           if (!existingMember) {
             const token = crypto.randomBytes(36).toString('hex');
-            const member = new Member(body.email, false, body.publicationId, token);
+            const member = new Member(body.email, false, token);
             await memberRepository.save(member);
 
             const publicationRepository = connection.getRepository(Publication);
@@ -64,7 +64,7 @@ export default async function GenericMemberHandler(req: NextApiRequest, res: Nex
         const member = await memberRepository.findOne({ id: memberId as string });
         if (member) {
           const publicationRepository = connection.getRepository(Publication);
-          const publication = await publicationRepository.findOneOrFail({ id: member.publicationId });
+          const publication = await publicationRepository.findOneOrFail();
           await sendVerificationMail(mailSettings, member.email, member.verificationToken || '', publication);
           res.status(201).end('Mail sent successfully.');
         } else {

--- a/pages/api/publication/import-members.ts
+++ b/pages/api/publication/import-members.ts
@@ -16,7 +16,6 @@ export const config = {
 export default async function ImportPublicationMembersHandler(req: NextApiRequest, res: NextApiResponse) {
   const {
     method,
-    query: { publicationId }
   } = req;
 
   const session = await getSession({ req });
@@ -40,7 +39,7 @@ export default async function ImportPublicationMembersHandler(req: NextApiReques
         const membersJson = await csv().fromString(contents);
         let importedMemberCount = 0;
         if (membersJson.length > 0) {
-          const uploadedMembers = membersJson.map(m => new Member(m.email, true, publicationId as any, crypto.randomBytes(36).toString('hex')));
+          const uploadedMembers = membersJson.map(m => new Member(m.email, true, crypto.randomBytes(36).toString('hex')));
           const connection = await dbConnection('members');
           const memberRepository = connection.getRepository(Member);
 

--- a/pages/feed.tsx
+++ b/pages/feed.tsx
@@ -1,0 +1,71 @@
+import { GetServerSideProps } from "next";
+import { Post, Publication } from "../models";
+import { dbConnection } from "../repository";
+import rss from 'rss';
+import { Component } from "react";
+
+export default class Feed extends Component { }
+
+export const getServerSideProps: GetServerSideProps = async ({ res, locale }): Promise<any> => {
+  if (!res) {
+    return;
+  }
+
+  const { publication, posts } = await getPublicationWithPosts();
+  if (!publication) {
+    return;
+  }
+
+  // TODO: Investigate caching the response
+  res.setHeader('Content-Type', 'text/xml');
+  res.write(getFeedXml(publication, posts, locale));
+  res.end();
+  return { props: {} };
+}
+
+const getPublicationWithPosts = async (): Promise<{
+  publication: Publication | undefined,
+  posts: Post[],
+}> => {
+  const connection = await dbConnection('publication');
+  const publicationRepository = connection.getRepository(Publication);
+  const publication = await publicationRepository.findOne();
+  const postRepository = connection.getRepository(Post);
+  const posts = await postRepository.find({ isPublished: true });
+  await connection.close();
+  return {
+    publication,
+    posts,
+  };
+}
+
+const getFeedXml = (publication: Publication, posts: Post[], locale: string | undefined) => {
+  let feed = new rss({
+    title: publication.name,
+    description: publication.description,
+    generator: 'Yappl',
+    feed_url: `${process.env.SITE_URL}/feed`,
+    site_url: `${process.env.SITE_URL}`,
+    image_url: publication.imageUrl,
+    copyright: publication.name,
+    language: locale,
+    pubDate: new Date().toLocaleString(),
+    ttl: 1440,
+  });
+
+  // TODO: Add iTunes and Google Play custom elements
+
+  posts.map(post =>
+    feed.item({
+      title: post.title,
+      description: post.subtitle,
+      url: post.canonicalUrl,
+      author: post.authorName,
+      date: post.publishedAt || '',
+      enclosure: post.tileImageUrl ? { url: post.tileImageUrl } : undefined,
+      // TODO: add raw content?
+    }));
+
+  const xmlString = feed.xml();
+  return xmlString;
+}

--- a/pages/import-members.tsx
+++ b/pages/import-members.tsx
@@ -1,20 +1,22 @@
 import axios from 'axios';
-import AdminContainer from '../../../components/adminContainer';
+import AdminContainer from '../components/adminContainer';
 import { useCallback, useState } from "react";
 import { useDropzone } from "react-dropzone";
-import { GetServerSideProps } from 'next';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 
-export default function ImportMembers(props: any) {
+export default function ImportMembers() {
   const [loading, setLoading] = useState(false);
   const [successMessage, setSuccessMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const router = useRouter();
+  const { setup } = router.query;
   const onDrop = useCallback(acceptedFiles => {
     setLoading(true);
     // TODO: Validate file format
     var formData = new FormData();
     formData.append('members', acceptedFiles[0]);
-    axios.post(`/api/publication/import-members?publicationId=${props.publicationId}`, formData, {
+    axios.post('/api/publication/import-members', formData, {
       headers: {
         'Content-Type': 'multipart/form-data'
       }
@@ -23,7 +25,11 @@ export default function ImportMembers(props: any) {
         setLoading(false)
         setErrorMessage('');
         setSuccessMessage(response.data);
-        window.location.href = `${window.location.origin}/dashboard`;
+        if (router.asPath.indexOf("setup=true") > -1) {
+          router.push('/dashboard')
+        } else {
+          router.push('/members');
+        }
       })
       .catch(error => {
         setLoading(false);
@@ -46,7 +52,7 @@ export default function ImportMembers(props: any) {
     <AdminContainer>
       <div className='full-page'>
         <div className='form-adjusted-width card-col mt-24'>
-          <img className='my-4 image-banner' src={require('../../../public/assets/post.svg')} alt='post' />
+          <img className='my-4 image-banner' src={require('../public/assets/post.svg')} alt='post' />
           <h2 className='text-center'>Import members using a CSV file</h2>
           <div className='my-4 relative'>
             {
@@ -65,11 +71,22 @@ export default function ImportMembers(props: any) {
             </div>
 
             <div className='text-center mt-4'>
-              <Link href="/dashboard">
-                <a>
-                  <strong>Skip this step</strong>
-                </a>
-              </Link>
+              {
+                setup === "true" &&
+                <Link href="/dashboard">
+                  <a>
+                    <strong>Skip this step</strong>
+                  </a>
+                </Link>
+              }
+              {
+                setup !== "true" &&
+                <Link href='/members'>
+                  <a>
+                    <strong>Cancel</strong>
+                  </a>
+                </Link>
+              }
             </div>
           </div>
           {
@@ -88,13 +105,4 @@ export default function ImportMembers(props: any) {
       </div>
     </AdminContainer>
   );
-}
-
-export const getServerSideProps: GetServerSideProps = async (context: any): Promise<any> => {
-  const { publicationId } = context.params;
-  return {
-    props: {
-      publicationId
-    }
-  };
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -58,7 +58,6 @@ export default function Index(props: {
                       setLoading(true);
                       axios.post('/api/member/subscribe', {
                         email,
-                        publicationId: publication.id
                       })
                         .then(response => {
                           setEmail('');

--- a/pages/members.tsx
+++ b/pages/members.tsx
@@ -2,7 +2,7 @@ import { GetServerSideProps } from "next";
 import { getSession } from "next-auth/client";
 import Head from "next/head";
 import AdminPageContainer from "../components/adminContainer";
-import { Member, Publication } from "../models";
+import { Member } from "../models";
 import { dbConnection } from "../repository";
 import moment from 'moment';
 import Tooltip from "../components/tooltip";
@@ -22,7 +22,6 @@ const toastConfig: ToastOptions = {
 
 export default function Members(props: {
   members: Member[],
-  publicationId: string,
 }) {
   const [memberToDelete, setMemberToDelete] = useState<Member | undefined>();
   const [deleteMemberLoading, setDeleteMemberLoading] = useState(false);
@@ -41,7 +40,7 @@ export default function Members(props: {
           <h2>Members ({props.members.length})</h2>
 
           <div className='flex justify-center items-center'>
-            <Link href={`/publication/${props.publicationId}/import-members`}>
+            <Link href={`/import-members`}>
               <a className='btn-default'>Import members</a>
             </Link>
           </div>
@@ -231,14 +230,11 @@ export const getServerSideProps: GetServerSideProps = async (context: any): Prom
   const connection = await dbConnection('member');
   const memberRepository = connection.getRepository(Member);
   const members = await memberRepository.createQueryBuilder('members').orderBy('members.created_at', 'DESC').getMany();
-  const publicationRepository = connection.getRepository(Publication);
-  const publication = await publicationRepository.findOne();
   await connection.close();
 
   return {
     props: {
       members: JSON.parse(JSON.stringify(members)),
-      publicationId: publication?.id,
     }
   };
 }

--- a/pages/publication/import/[userId].tsx
+++ b/pages/publication/import/[userId].tsx
@@ -28,9 +28,9 @@ export default function ImportPublication() {
                   rssFeedUrl,
                   source: 'rss'
                 }, { withCredentials: true })
-                  .then(response => {
+                  .then(() => {
                     setErrorMessage('');
-                    window.location.href = `${window.location.origin}/publication/${response.data}/import-members`;
+                    router.push(`/mail-settings?setup=true`);
                   })
                   .catch(error => {
                     setLoading(false);

--- a/pages/publication/new/[userId].tsx
+++ b/pages/publication/new/[userId].tsx
@@ -38,9 +38,9 @@ export default function NewPublication() {
                   description,
                   imageUrl,
                 }, { withCredentials: true })
-                  .then(response => {
+                  .then(() => {
                     setErrorMessage('');
-                    window.location.href = `${window.location.origin}/publication/${response.data}/import-members`;
+                    router.push(`/mail-settings?setup=true`);
                   })
                   .catch(error => {
                     setLoading(false);

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import Container from '../components/container';
 import { csrfToken } from "next-auth/client";
 import SpinnerButton from "../components/spinnerButton";
+import { useRouter } from "next/router";
 
 export default function SignUp(props: any) {
   const [image, setImage] = useState('');
@@ -12,6 +13,7 @@ export default function SignUp(props: any) {
   const [passwordConfirmation, setPasswordConfirmation] = useState('');
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
+  const router = useRouter();
 
   return (
     <Container>
@@ -40,7 +42,7 @@ export default function SignUp(props: any) {
                       password
                     })
                       .then(response => {
-                        window.location.href = `${window.location.origin}/publication/setup/${userId}`;
+                        router.push(`/publication/setup/${userId}`);
                       })
                       .catch(error => {
                         setLoading(false);

--- a/pages/sitemap.tsx
+++ b/pages/sitemap.tsx
@@ -1,0 +1,41 @@
+import { GetServerSideProps } from "next";
+import { Component } from "react";
+import { SitemapStream, streamToPromise } from "sitemap";
+import { Post } from "../models";
+import { dbConnection } from "../repository";
+
+export default class Sitemap extends Component { }
+
+export const getServerSideProps: GetServerSideProps = async ({ res }): Promise<any> => {
+  if (!res) {
+    return;
+  }
+
+  const posts = await getPosts();
+  const sitemapStream = new SitemapStream({
+    hostname: process.env.SITE_URL,
+  });
+
+  posts.map(post =>
+    sitemapStream.write({
+      url: post.canonicalUrl,
+      changefreq: 'weekly',
+      priority: 0.9,
+    })
+  );
+
+  sitemapStream.end();
+  const sitemapOutput = (await streamToPromise(sitemapStream)).toString();
+  res.setHeader('Content-Type', 'text/xml');
+  res.write(sitemapOutput); // TODO: Investigate caching response
+  res.end();
+  return { props: {} };
+}
+
+const getPosts = async (): Promise<Post[]> => {
+  const connection = await dbConnection('posts');
+  const postRepository = connection.getRepository(Post);
+  const posts = await postRepository.find({ isPublished: true });
+  await connection.close();
+  return posts;
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,3 +5,6 @@ Disallow: /signup
 Disallow: /dashboard
 Disallow: /auth/*
 Disallow: /api/*
+Disallow: /members
+Disallow: /import-members
+Disallow: /mail-settings


### PR DESCRIPTION
* Save draftjs raw content to db

* New and improved wysiwyg editor

* Changed html on post to article

* Updated dashboard links

* Link component for draftail editor

* Member page with logic to delete and send emails to members

* Route fix

* Refactored member endpoints to include delete and email verification actions

* Added toast messages on members page

* Tile image URL prop on post

* Small styling fix

* Extra publish step (page)

* Renamed component issueCard to postCard

* Add image on post card

* Import members using csv file

* style link in draftjs editor

* Convert html to draftjs content

* Styling fix for lists

* Add favicon on public pages

* Dashboard button styling

* Moved import-members page to pages folder

* Remove publication Id from member model

* Simplified member importing

* Removed remaining publicationId values from member

* Small modification in member import flow

* Added mail settings in setup steps

* Fix rss import bug - published date not imported

* Simplified updating of mail settings

* Add rss feed for publication

* Add sitemap for publication